### PR TITLE
Add missing tooltip parts for HideFlags

### DIFF
--- a/hideflags/index.html
+++ b/hideflags/index.html
@@ -25,6 +25,14 @@ script: true
 			<input type="checkbox" id="place" data-value="16">
 			<label for="place">CanPlace</label>
 		</li>
+		<li>
+			<input type="checkbox" id="additional" data-value="32">
+			<label for="additional">Additional</label>
+		</li>
+		<li>
+			<input type="checkbox" id="dye" data-value="64">
+			<label for="dye">Dye</label>
+		</li>
 	</ul>
 
 	<input


### PR DESCRIPTION
This pull requests adds the missing tooltip parts `Additional` and `Dye`. This is also what they're named internally:
![](https://user-images.githubusercontent.com/51272202/202861852-1c3e6169-e83a-4858-a65f-511acd376024.png)

"Additional" hides potion effects, book and firework information, map tooltips, patterns of banners, and enchantments of enchanted books.

"Dye" hides the "Dyed" tooltip on leather armor.